### PR TITLE
Validate and normalize tracker player input (Steam/BattleMetrics IDs + URLs)

### DIFF
--- a/src/handlers/modalHandler.js
+++ b/src/handlers/modalHandler.js
@@ -22,9 +22,11 @@ const Discord = require('discord.js');
 
 const Battlemetrics = require('../structures/Battlemetrics');
 const Constants = require('../util/constants.js');
+const DiscordEmbeds = require('../discordTools/discordEmbeds.js');
 const DiscordMessages = require('../discordTools/discordMessages.js');
 const Keywords = require('../util/keywords.js');
 const Scrape = require('../util/scrape.js');
+const TrackerInputParser = require('../util/trackerInputParser.js');
 
 module.exports = async (client, interaction) => {
     const instance = client.getInstance(interaction.guildId);
@@ -322,18 +324,38 @@ module.exports = async (client, interaction) => {
     else if (interaction.customId.startsWith('TrackerAddPlayer')) {
         const ids = JSON.parse(interaction.customId.replace('TrackerAddPlayer', ''));
         const tracker = instance.trackers[ids.trackerId];
-        const id = interaction.fields.getTextInputValue('TrackerAddPlayerId');
+        const input = interaction.fields.getTextInputValue('TrackerAddPlayerId');
 
         if (!tracker) {
             interaction.deferUpdate();
             return;
         }
 
-        const isSteamId64 = id.length === Constants.STEAMID64_LENGTH ? true : false;
+        const parsedInput = TrackerInputParser.parseTrackerPlayerInput(input);
+        if (!parsedInput.valid) {
+            const str = client.intlGet(interaction.guildId, 'trackerPlayerInputInvalid');
+            await client.interactionReply(interaction, DiscordEmbeds.getActionInfoEmbed(1, str));
+            return;
+        }
+
+        let id = parsedInput.value;
+        let isSteamId64 = parsedInput.type === 'steamId';
+        if (parsedInput.type === 'steamVanityUrl') {
+            const resolvedSteamId = await Scrape.scrapeSteamIdFromVanity(client, parsedInput.value);
+            if (!resolvedSteamId) {
+                const str = client.intlGet(interaction.guildId, 'trackerPlayerInputInvalid');
+                await client.interactionReply(interaction, DiscordEmbeds.getActionInfoEmbed(1, str));
+                return;
+            }
+
+            id = resolvedSteamId;
+            isSteamId64 = true;
+        }
+
         const bmInstance = client.battlemetricsInstances[tracker.battlemetricsId];
 
         if ((isSteamId64 && tracker.players.some(e => e.steamId === id)) ||
-            (!isSteamId64 && tracker.players.some(e => e.playerId === id && e.steamId === null))) {
+            (!isSteamId64 && tracker.players.some(e => e.playerId === id))) {
             interaction.deferUpdate();
             return;
         }
@@ -353,7 +375,7 @@ module.exports = async (client, interaction) => {
         }
         else {
             playerId = id;
-            if (bmInstance.players.hasOwnProperty(id)) {
+            if (bmInstance && bmInstance.players.hasOwnProperty(id)) {
                 name = bmInstance.players[id]['name'];
             }
             else {
@@ -378,21 +400,48 @@ module.exports = async (client, interaction) => {
     else if (interaction.customId.startsWith('TrackerRemovePlayer')) {
         const ids = JSON.parse(interaction.customId.replace('TrackerRemovePlayer', ''));
         const tracker = instance.trackers[ids.trackerId];
-        const id = interaction.fields.getTextInputValue('TrackerRemovePlayerId');
-
-        const isSteamId64 = id.length === Constants.STEAMID64_LENGTH ? true : false;
+        const input = interaction.fields.getTextInputValue('TrackerRemovePlayerId');
 
         if (!tracker) {
             interaction.deferUpdate();
             return;
         }
 
-        if (isSteamId64) {
+        const parsedInput = TrackerInputParser.parseTrackerPlayerInput(input);
+        let id = parsedInput.valid ? parsedInput.value : parsedInput.normalizedInput;
+        let isSteamId64 = parsedInput.valid ? parsedInput.type === 'steamId' : false;
+        let useRawRemoval = !parsedInput.valid;
+        if (parsedInput.valid && parsedInput.type === 'steamVanityUrl') {
+            const resolvedSteamId = await Scrape.scrapeSteamIdFromVanity(client, parsedInput.value);
+            if (resolvedSteamId) {
+                id = resolvedSteamId;
+                isSteamId64 = true;
+            }
+            else {
+                useRawRemoval = true;
+                id = parsedInput.normalizedInput;
+                isSteamId64 = false;
+            }
+        }
+
+        const previousLength = tracker.players.length;
+
+        if (useRawRemoval) {
+            tracker.players = tracker.players.filter(e => e.steamId !== id && e.playerId !== id);
+        }
+        else if (isSteamId64) {
             tracker.players = tracker.players.filter(e => e.steamId !== id);
         }
         else {
-            tracker.players = tracker.players.filter(e => e.playerId !== id || e.steamId !== null);
+            tracker.players = tracker.players.filter(e => e.playerId !== id);
         }
+
+        if (useRawRemoval && previousLength === tracker.players.length) {
+            const str = client.intlGet(interaction.guildId, 'trackerPlayerInputInvalid');
+            await client.interactionReply(interaction, DiscordEmbeds.getActionInfoEmbed(1, str));
+            return;
+        }
+
         client.setInstance(interaction.guildId, instance);
 
         client.log(client.intlGet(null, 'infoCap'), client.intlGet(null, 'modalValueChange', {

--- a/src/languages/cs.json
+++ b/src/languages/cs.json
@@ -747,6 +747,7 @@
     "total": "Total",
     "tracker": "Tracker",
     "trackerAddPlayerDesc": "Přidat hráče do {tracker}",
+    "trackerPlayerInputInvalid": "Neplatný vstup hráče trackeru. Použijte SteamID64, ID hráče BattleMetrics, URL profilu Steam (/profiles/), URL Steam vanity (/id/) nebo URL hráče BattleMetrics.",
     "trackerRemovePlayerDesc": "Odstranit hráče z {tracker}",
     "trademarkShownBeforeMessage": "{trademark} se zobrazí před zprávami.",
     "trainYard": "Nádraží",

--- a/src/languages/de.json
+++ b/src/languages/de.json
@@ -748,6 +748,7 @@
     "total": "Gesamt",
     "tracker": "Tracker",
     "trackerAddPlayerDesc": "Spieler zu `{tracker}` hinzufügen",
+    "trackerPlayerInputInvalid": "Ungültige Eingabe des Trackerspielers. Verwenden Sie eine SteamID64, eine BattleMetrics-Spieler-ID, eine Steam-Profil-URL (/profiles/), eine Steam-Vanity-URL (/id/) oder eine BattleMetrics-Spieler-URL.",
     "trackerRemovePlayerDesc": "Entferne Spieler von `{tracker}`",
     "trademarkShownBeforeMessage": "{trademark} wird vor Nachrichten angezeigt.",
     "trainYard": "Güterbahnhof",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -439,6 +439,7 @@
     "invalidGuildOrChannel": "Invalid guild or channel.",
     "invalidHpInterval": "Invalid HP interval {hp}.",
     "invalidId": "Invalid ID: {id}.",
+    "trackerPlayerInputInvalid": "Invalid tracker player input. Use a SteamID64, BattleMetrics player ID, Steam profile URL (/profiles/), Steam vanity URL (/id/), or BattleMetrics player URL.",
     "invalidStructureType": "Invalid Structure type {type}.",
     "invalidSubcommand": "Invalid subcommand.",
     "invalidTimeDistance": "Invalid time distance: {distance}, prev: {prevTime}, new: {newTime}",

--- a/src/languages/es.json
+++ b/src/languages/es.json
@@ -747,6 +747,7 @@
     "total": "Total",
     "tracker": "Tracker",
     "trackerAddPlayerDesc": "Añadir jugador a {tracker}",
+    "trackerPlayerInputInvalid": "Entrada del jugador del rastreador no válida. Utiliza un SteamID64, un ID de jugador de BattleMetrics, una URL de perfil de Steam (/profiles/), una URL personalizada de Steam (/id/) o una URL de jugador de BattleMetrics.",
     "trackerRemovePlayerDesc": "Eliminar jugador de {tracker}",
     "trademarkShownBeforeMessage": "{trademark} se mostrará antes de los mensajes.",
     "trainYard": "Patio ferroviario",

--- a/src/languages/fr.json
+++ b/src/languages/fr.json
@@ -747,6 +747,7 @@
     "total": "Total",
     "tracker": "Tracker",
     "trackerAddPlayerDesc": "Ajouter un joueur au {tracker}",
+    "trackerPlayerInputInvalid": "Entrée de joueur invalide. Utilisez un SteamID64, un identifiant de joueur BattleMetrics, une URL de profil Steam (/profiles/), une URL personnalisée Steam (/id/) ou une URL de joueur BattleMetrics.",
     "trackerRemovePlayerDesc": "Retirer un joueur depuie le {tracker}",
     "trademarkShownBeforeMessage": "{trademark} sera affiché avant les messages.",
     "trainYard": "Gare de Triage",

--- a/src/languages/it.json
+++ b/src/languages/it.json
@@ -747,6 +747,7 @@
     "total": "Total",
     "tracker": "Tracker",
     "trackerAddPlayerDesc": "Aggiungi giocatore a {tracker}",
+    "trackerPlayerInputInvalid": "Input giocatore tracker non valido. Utilizza uno SteamID64, un ID giocatore BattleMetrics, un URL profilo Steam (/profiles/), un URL personalizzato Steam (/id/) o un URL giocatore BattleMetrics.",
     "trackerRemovePlayerDesc": "Rimuovi giocatore da {tracker}",
     "trademarkShownBeforeMessage": "{trademark} sarà mostrato prima dei messaggi.",
     "trainYard": "Cantiere dei Treni",

--- a/src/languages/ko.json
+++ b/src/languages/ko.json
@@ -747,6 +747,7 @@
     "total": "Total",
     "tracker": "Tracker",
     "trackerAddPlayerDesc": "{tracker} 에 플레이어 추가",
+    "trackerPlayerInputInvalid": "추적기 플레이어 입력값이 잘못되었습니다. SteamID64, BattleMetrics 플레이어 ID, Steam 프로필 URL(/profiles/), Steam 바니티 URL(/id/), 또는 BattleMetrics 플레이어 URL을 사용하세요.",
     "trackerRemovePlayerDesc": "{tracker} 에서 플레이어 제거",
     "trademarkShownBeforeMessage": "메시지 앞에 {trademark}가 표시됩니다.",
     "trainYard": "기차 차고지",

--- a/src/languages/pl.json
+++ b/src/languages/pl.json
@@ -747,6 +747,7 @@
     "total": "Total",
     "tracker": "Tracker",
     "trackerAddPlayerDesc": "Dodaj gracza do {tracker}",
+    "trackerPlayerInputInvalid": "Nieprawidłowe dane gracza trackera. Użyj SteamID64, identyfikatora gracza BattleMetrics, adresu URL profilu Steam (/profiles/), adresu URL Steam (/id/) lub adresu URL gracza BattleMetrics.",
     "trackerRemovePlayerDesc": "Usuń Gracza z {tracker}",
     "trademarkShownBeforeMessage": "{trademark} will be shown before messages.",
     "trainYard": "Zajezdnia kolejowa",

--- a/src/languages/pt.json
+++ b/src/languages/pt.json
@@ -747,6 +747,7 @@
     "total": "Total",
     "tracker": "Rastreador",
     "trackerAddPlayerDesc": "Adicionar Jogador ao {tracker}",
+    "trackerPlayerInputInvalid": "Entrada inválida do jogador no rastreador. Use um SteamID64, ID de jogador BattleMetrics, URL do perfil Steam (/profiles/), URL personalizada Steam (/id/) ou URL do jogador BattleMetrics.",
     "trackerRemovePlayerDesc": "Remover Jogador de {tracker}",
     "trademarkShownBeforeMessage": "{trademark} será exibido antes das mensagens.",
     "trainYard": "Estação de Comboios",

--- a/src/languages/ru.json
+++ b/src/languages/ru.json
@@ -747,6 +747,7 @@
     "total": "Всего",
     "tracker": "Трекер",
     "trackerAddPlayerDesc": "Добавить игрока в {tracker}",
+    "trackerPlayerInputInvalid": "Недопустимый ввод игрока трекера. Используйте SteamID64, ID игрока BattleMetrics, URL профиля Steam (/profiles/), URL Steam (/id/) или URL игрока BattleMetrics.",
     "trackerRemovePlayerDesc": "Удалить игрока из {tracker}",
     "trademarkShownBeforeMessage": "{trademark} будет отображаться перед сообщениями.",
     "trainYard": "Железнодорожное депо",

--- a/src/languages/sv.json
+++ b/src/languages/sv.json
@@ -747,6 +747,7 @@
     "total": "Total",
     "tracker": "Tracker",
     "trackerAddPlayerDesc": "Lägg till spelare till {tracker}",
+    "trackerPlayerInputInvalid": "Ogiltig tracker-spelarindata. Använd ett SteamID64, BattleMetrics-spelar-ID, Steam-profil-URL (/profiles/), Steam-vanity-URL (/id/) eller BattleMetrics-spelar-URL.",
     "trackerRemovePlayerDesc": "Ta bort spelare från {tracker}",
     "trademarkShownBeforeMessage": "{trademark} kommer att visas före meddelanden.",
     "trainYard": "Tåggård",

--- a/src/languages/tr.json
+++ b/src/languages/tr.json
@@ -747,6 +747,7 @@
     "total": "Toplam",
     "tracker": "İzleyici",
     "trackerAddPlayerDesc": "Oyuncu Ekle - {tracker}",
+    "trackerPlayerInputInvalid": "Geçersiz izleyici oyuncu girişi. SteamID64, BattleMetrics oyuncu kimliği, Steam profil URL'si (/profiles/), Steam vanity URL'si (/id/) veya BattleMetrics oyuncu URL'si kullanın.",
     "trackerRemovePlayerDesc": "Oyuncu Sil - {tracker}",
     "trademarkShownBeforeMessage": "{trademark} mesajlardan önce gösterilecek.",
     "trainYard": "Tren İstasyonu",

--- a/src/util/scrape.js
+++ b/src/util/scrape.js
@@ -69,4 +69,27 @@ module.exports = {
 
         return null;
     },
+
+    scrapeSteamIdFromVanity: async function (client, vanity) {
+        if (typeof vanity !== 'string' || vanity.trim() === '') return null;
+
+        const url = `https://steamcommunity.com/id/${encodeURIComponent(vanity.trim())}/?xml=1`;
+        const response = await module.exports.scrape(url);
+
+        if (response.status !== 200 || typeof response.data !== 'string') {
+            return null;
+        }
+
+        const steamId64Match = response.data.match(/<steamID64>(\d{17})<\/steamID64>/i);
+        if (steamId64Match) {
+            return steamId64Match[1];
+        }
+
+        const profileLinkMatch = response.data.match(/steamcommunity\.com\/profiles\/(\d{17})/i);
+        if (profileLinkMatch) {
+            return profileLinkMatch[1];
+        }
+
+        return null;
+    },
 }

--- a/src/util/trackerInputParser.js
+++ b/src/util/trackerInputParser.js
@@ -1,0 +1,138 @@
+/*
+    Copyright (C) 2026 FaiThiX
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+    https://github.com/faithix/rustplusplus
+
+*/
+
+const Constants = require('./constants.js');
+
+function normalizeInput(input) {
+    if (typeof input !== 'string') return '';
+
+    let normalized = input.trim();
+
+    if (normalized.startsWith('<') && normalized.endsWith('>')) {
+        normalized = normalized.slice(1, -1).trim();
+    }
+
+    return normalized;
+}
+
+function isSteamId64(input) {
+    return new RegExp(`^\\d{${Constants.STEAMID64_LENGTH}}$`).test(input);
+}
+
+function isBattlemetricsPlayerId(input) {
+    return /^\d+$/.test(input);
+}
+
+function parseSteamProfileUrl(pathname) {
+    const parts = pathname.split('/').filter(Boolean);
+    if (parts.length < 2 || parts[0].toLowerCase() !== 'profiles') return null;
+
+    const steamId = parts[1];
+    return isSteamId64(steamId) ? steamId : null;
+}
+
+function parseSteamVanityUrl(pathname) {
+    const parts = pathname.split('/').filter(Boolean);
+    if (parts.length < 2 || parts[0].toLowerCase() !== 'id') return null;
+
+    const vanity = parts[1].trim();
+    if (vanity === '') return null;
+
+    return vanity;
+}
+
+function parseBattlemetricsPlayerUrl(pathname) {
+    const parts = pathname.split('/').filter(Boolean);
+    const playersIndex = parts.findIndex(part => part.toLowerCase() === 'players');
+    if (playersIndex === -1 || !parts[playersIndex + 1]) return null;
+
+    const playerId = parts[playersIndex + 1];
+    return isBattlemetricsPlayerId(playerId) ? playerId : null;
+}
+
+module.exports = {
+    parseTrackerPlayerInput: function (input) {
+        const normalizedInput = normalizeInput(input);
+
+        if (normalizedInput === '') {
+            return { valid: false, value: null, type: null, normalizedInput: normalizedInput };
+        }
+
+        if (isSteamId64(normalizedInput)) {
+            return { valid: true, value: normalizedInput, type: 'steamId', normalizedInput: normalizedInput };
+        }
+
+        if (isBattlemetricsPlayerId(normalizedInput)) {
+            return {
+                valid: true,
+                value: normalizedInput,
+                type: 'battlemetricsId',
+                normalizedInput: normalizedInput
+            };
+        }
+
+        let url = null;
+        try {
+            url = new URL(normalizedInput);
+        }
+        catch (e) {
+            return { valid: false, value: null, type: null, normalizedInput: normalizedInput };
+        }
+
+        const hostname = url.hostname.toLowerCase();
+
+        if (hostname === 'steamcommunity.com' || hostname === 'www.steamcommunity.com') {
+            const steamId = parseSteamProfileUrl(url.pathname);
+            if (steamId) {
+                return { valid: true, value: steamId, type: 'steamId', normalizedInput: normalizedInput };
+            }
+
+            const vanity = parseSteamVanityUrl(url.pathname);
+            if (vanity) {
+                return {
+                    valid: true,
+                    value: vanity,
+                    type: 'steamVanityUrl',
+                    normalizedInput: normalizedInput
+                };
+            }
+
+            return { valid: false, value: null, type: null, normalizedInput: normalizedInput };
+        }
+
+        if (hostname === 'battlemetrics.com' ||
+            hostname === 'www.battlemetrics.com' ||
+            hostname === 'api.battlemetrics.com') {
+            const battlemetricsId = parseBattlemetricsPlayerUrl(url.pathname);
+            if (!battlemetricsId) {
+                return { valid: false, value: null, type: null, normalizedInput: normalizedInput };
+            }
+
+            return {
+                valid: true,
+                value: battlemetricsId,
+                type: 'battlemetricsId',
+                normalizedInput: normalizedInput
+            };
+        }
+
+        return { valid: false, value: null, type: null, normalizedInput: normalizedInput };
+    }
+};


### PR DESCRIPTION
## Summary
This PR validates and normalizes tracker player input before saving it, so malformed values can no longer break tracker management.

Closes #14

## Problem
Tracker player entries previously accepted arbitrary raw input.  
That allowed invalid values to be stored, which could lead to:
- broken tracker entries,
- failed removals,
- and in some cases tracker cleanup issues.

## What changed
- Added a dedicated tracker input parser used by both **Add Player** and **Remove Player** flows.
- Supported/normalized input formats:
- SteamID64 (`7656119...`)
- BattleMetrics player ID (`12345678`)
- Steam profile URL (`https://steamcommunity.com/profiles/<steamid64>`)
- Steam vanity URL (`https://steamcommunity.com/id/<name>`) -> resolved to SteamID64
- BattleMetrics player URL (`https://www.battlemetrics.com/players/<id>`)
- Invalid or unsupported input now returns a clear user-facing error instead of being saved.
- Remove flow now uses the same parsing logic and includes a fallback to remove legacy malformed raw entries.

## Implementation details
- Added: `src/util/trackerInputParser.js`
- Updated: `src/handlers/modalHandler.js`
- Updated: `src/util/scrape.js` (vanity -> SteamID64 resolver)
- Updated: `src/languages/en.json` (new validation error message)

## Validation
- `node --check src/handlers/modalHandler.js`
- `node --check src/util/trackerInputParser.js`
- `node --check src/util/scrape.js`
- `npm test -- --pretty false`

## Impact
- Tracker data is now stored in consistent internal formats.
- Invalid tracker input is rejected early with clear feedback.
- Improves tracker stability without changing existing tracker behavior for valid inputs.
