### PR TITLE
fix(discord): support least-privilege bot permissions without Administrator

### DIFF
--- a/src/discordTools/SetupGuildCategory.js
+++ b/src/discordTools/SetupGuildCategory.js
@@ -18,30 +18,48 @@
 
 */
 
+const Discord = require('discord.js');
 const DiscordTools = require('../discordTools/discordTools.js');
 const PermissionHandler = require('../handlers/permissionHandler.js');
 
 module.exports = async (client, guild) => {
     const instance = client.getInstance(guild.id);
+    const perms = PermissionHandler.getPermissionsReset(client, guild, false);
 
     let category = undefined;
     if (instance.channelId.category !== null) {
         category = DiscordTools.getCategoryById(guild.id, instance.channelId.category);
+        if (category && !botHasChannelPermissions(guild, category)) {
+            category = undefined;
+        }
     }
     if (category === undefined) {
-        category = await DiscordTools.addCategory(guild.id, 'rustplusplus');
+        category = await DiscordTools.addCategory(guild.id, 'rustplusplus', perms);
+        if (!category) {
+            return undefined;
+        }
         instance.channelId.category = category.id;
         client.setInstance(guild.id, instance);
     }
-
-    const perms = PermissionHandler.getPermissionsReset(client, guild, false);
 
     try {
         await category.permissionOverwrites.set(perms);
     }
     catch (e) {
-        /* Ignore */
+        client.log(client.intlGet(null, 'errorCap'),
+            `Could not set permission overwrites for category ${category.id}: ${e}`, 'error');
     }
 
     return category;
 };
+
+function botHasChannelPermissions(guild, channel) {
+    const me = guild.members?.me;
+    if (!me) return true;
+
+    const permissions = channel.permissionsFor(me);
+    return permissions?.has([
+        Discord.PermissionFlagsBits.ViewChannel,
+        Discord.PermissionFlagsBits.ManageChannels
+    ]) ?? false;
+}

--- a/src/discordTools/SetupGuildChannels.js
+++ b/src/discordTools/SetupGuildChannels.js
@@ -18,10 +18,15 @@
 
 */
 
+const Discord = require('discord.js');
 const DiscordTools = require('../discordTools/discordTools.js');
 const PermissionHandler = require('../handlers/permissionHandler.js');
 
 module.exports = async (client, guild, category) => {
+    if (!category) {
+        return;
+    }
+
     await addTextChannel(client.intlGet(guild.id, 'channelNameInformation'), 'information', client, guild, category);
     await addTextChannel(client.intlGet(guild.id, 'channelNameServers'), 'servers', client, guild, category);
     await addTextChannel(client.intlGet(guild.id, 'channelNameSettings'), 'settings', client, guild, category);
@@ -39,47 +44,57 @@ module.exports = async (client, guild, category) => {
 
 async function addTextChannel(name, idName, client, guild, parent, permissionWrite = false) {
     const instance = client.getInstance(guild.id);
+    const perms = PermissionHandler.getPermissionsReset(client, guild, permissionWrite);
 
     let channel = undefined;
     if (instance.channelId[idName] !== null) {
         channel = DiscordTools.getTextChannelById(guild.id, instance.channelId[idName]);
+        if (channel && !botCanUseTextChannel(guild, channel)) {
+            instance.channelId[idName] = null;
+            client.setInstance(guild.id, instance);
+            channel = undefined;
+        }
     }
     if (channel === undefined) {
-        channel = await DiscordTools.addTextChannel(guild.id, name);
+        channel = await DiscordTools.addTextChannel(guild.id, name, parent.id, perms);
+        if (!channel) {
+            return;
+        }
         instance.channelId[idName] = channel.id;
         client.setInstance(guild.id, instance);
+    }
 
+    if (channel && (instance.firstTime || channel.parentId !== parent.id)) {
         try {
-            channel.setParent(parent.id);
+            await channel.setParent(parent.id, { lockPermissions: false });
         }
         catch (e) {
             client.log(client.intlGet(null, 'errorCap'),
-                client.intlGet(null, 'couldNotSetParent', { channelId: channel.id }), 'error');
+                `${client.intlGet(null, 'couldNotSetParent', { channelId: channel.id })}: ${e}`, 'error');
         }
     }
-
-    if (instance.firstTime) {
-        try {
-            channel.setParent(parent.id);
-        }
-        catch (e) {
-            client.log(client.intlGet(null, 'errorCap'),
-                client.intlGet(null, 'couldNotSetParent', { channelId: channel.id }), 'error');
-        }
-    }
-
-    const perms = PermissionHandler.getPermissionsReset(client, guild, permissionWrite);
 
     try {
         await channel.permissionOverwrites.set(perms);
     }
     catch (e) {
-        /* Ignore */
+        client.log(client.intlGet(null, 'errorCap'),
+            `Could not set permission overwrites for channel ${channel.id}: ${e}`, 'error');
     }
 
     /* Currently, this halts the entire application... Too lazy to fix...
        It is possible to just remove the channels and let the bot recreate them with correct name language */
     //channel.setName(name);
+}
 
-    channel.lockPermissions();
+function botCanUseTextChannel(guild, channel) {
+    const me = guild.members?.me;
+    if (!me) return true;
+
+    const permissions = channel.permissionsFor(me);
+    return permissions?.has([
+        Discord.PermissionFlagsBits.ViewChannel,
+        Discord.PermissionFlagsBits.SendMessages,
+        Discord.PermissionFlagsBits.ManageChannels
+    ]) ?? false;
 }

--- a/src/discordTools/discordTools.js
+++ b/src/discordTools/discordTools.js
@@ -181,7 +181,7 @@ module.exports = {
         return undefined;
     },
 
-    addCategory: async function (guildId, name) {
+    addCategory: async function (guildId, name, permissionOverwrites = null) {
         const guild = module.exports.getGuild(guildId);
 
         if (guild) {
@@ -189,7 +189,7 @@ module.exports = {
                 return await guild.channels.create({
                     name: name,
                     type: Discord.ChannelType.GuildCategory,
-                    permissionOverwrites: [{
+                    permissionOverwrites: permissionOverwrites ?? [{
                         id: guild.roles.everyone.id,
                         deny: [Discord.PermissionFlagsBits.SendMessages]
                     }]
@@ -217,19 +217,25 @@ module.exports = {
         return true;
     },
 
-    addTextChannel: async function (guildId, name) {
+    addTextChannel: async function (guildId, name, parentId = null, permissionOverwrites = null) {
         const guild = module.exports.getGuild(guildId);
 
         if (guild) {
             try {
-                return await guild.channels.create({
+                const options = {
                     name: name,
                     type: Discord.ChannelType.GuildText,
-                    permissionOverwrites: [{
+                    permissionOverwrites: permissionOverwrites ?? [{
                         id: guild.roles.everyone.id,
                         deny: [Discord.PermissionFlagsBits.SendMessages]
                     }],
-                });
+                };
+
+                if (parentId !== null) {
+                    options.parent = parentId;
+                }
+
+                return await guild.channels.create(options);
             }
             catch (e) {
                 Client.client.log(Client.client.intlGet(null, 'errorCap'),

--- a/src/handlers/permissionHandler.js
+++ b/src/handlers/permissionHandler.js
@@ -67,6 +67,18 @@ module.exports = {
             });
         }
 
+        const botId = client.user?.id;
+        if (botId) {
+            perms.push({
+                id: botId,
+                allow: [
+                    Discord.PermissionFlagsBits.ViewChannel,
+                    Discord.PermissionFlagsBits.SendMessages,
+                    Discord.PermissionFlagsBits.ReadMessageHistory
+                ]
+            });
+        }
+
         return perms;
     },
 
@@ -86,6 +98,18 @@ module.exports = {
             id: guild.roles.everyone.id,
             deny: [Discord.PermissionFlagsBits.ViewChannel, Discord.PermissionFlagsBits.SendMessages]
         });
+
+        const botId = client.user?.id;
+        if (botId) {
+            perms.push({
+                id: botId,
+                allow: [
+                    Discord.PermissionFlagsBits.ViewChannel,
+                    Discord.PermissionFlagsBits.SendMessages,
+                    Discord.PermissionFlagsBits.ReadMessageHistory
+                ]
+            });
+        }
 
         return perms;
     },


### PR DESCRIPTION
## Summary

This PR removes the need to run the bot with `Administrator` and makes the Discord channel setup flow more reliable when using a minimal permission set.

The main issue was that the bot could create categories/channels and send messages, but it failed when applying channel/category permission overwrites. This PR updates the setup flow so the bot can safely work with explicit Discord permissions instead of relying on `Administrator`.

## What Changed

- Added explicit bot permission overwrites so the bot does not lock itself out of its own channels.
- Created categories and text channels with their intended parent/overwrites during creation, instead of relying on a fragile create-then-fix flow.
- Updated channel parent handling to use `await` and `lockPermissions: false` to avoid overwrite conflicts during setup.
- Added recovery logic for stored channel IDs that exist but are no longer usable by the bot.
- Improved setup logging so permission-related failures are now visible at the exact API call that failed.

## Why

The previous setup could fail in partially configured guilds because:
- the bot was able to create channels,
- but failed when updating permission overwrites,
- and in some cases could also end up with broken parent/permission sync behavior.

With this change, the bot now works correctly with a proper minimal permission set and no longer requires `Administrator`.

## Required Bot Scopes

- `bot`
- `applications.commands`

## Required Bot Permissions

These permissions are required for normal full operation with the current codebase:

- `View Channels`
- `Manage Channels`
- `Manage Roles`
- `Send Messages`
- `Embed Links`
- `Attach Files`
- `Read Message History`
- `Manage Messages`

## Optional Bot Permissions

These are only needed if the related features are used:

- `Mention Everyone`
  Required for `@everyone` / `@here` notification features.
- `Change Nickname`
  Required if the bot should set/update its server nickname on startup.
- `Connect`
  Required for voice channel features.
- `Speak`
  Required for voice playback features.
- `Send TTS Messages`
  Required for Discord TTS output.

## Not Required

The bot does not require:

- `Administrator`
- `Kick Members`
- `Ban Members`
- `Manage Webhooks`
- `Manage Guild`
- thread permissions
- moderation/timeouts permissions

## Result

The bot can now be installed with a least-privilege permission model while still supporting channel creation, overwrite management, embeds, attachments, and normal setup automation.
